### PR TITLE
Proposal: use cmake to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.kdev4
+fort.[1-9][0-9]

--- a/src/Appl/CMakeLists.txt
+++ b/src/Appl/CMakeLists.txt
@@ -1,24 +1,6 @@
-
-#gfortran -c -O3 Appl/BPM.f90
-#gfortran -c -O3 Appl/CCL.f90
-#gfortran -c -O3 Appl/CCDTL.f90
-#gfortran -c -O3 Appl/DTL.f90
-#gfortran -c -O3 Appl/SC.f90
-#gfortran -c -O3 Appl/DriftTube.f90
-#gfortran -c -O3 Appl/Quadrupole.f90
-#gfortran -c -O3 Appl/ConstFoc.f90
-#gfortran -c -O3 Appl/SolRF.f90
-#gfortran -c -O3 Appl/Sol.f90
-#gfortran -c -O3 Appl/Dipole.f90
-#gfortran -c -O3 Appl/Multipole.f90
-#gfortran -c -O3 Appl/EMfld.f90
-#gfortran -c -O3 Appl/TWS.f90
-#gfortran -c -O3 Appl/BeamLineElem.f90
-#gfortran -c -O3 Appl/CompDom.f90
-#gfortran -c -O3 Appl/Field.f90
-#gfortran -c -O3 Appl/BeamBunch.f90
-#gfortran -c -O3 Appl/Distribution.f90
-
 add_library(impact_appl BPM.f90 CCL.f90 CCDTL.f90 DTL.f90 SC.f90 DriftTube.f90 Quadrupole.f90 ConstFoc.f90 SolRF.f90 Sol.f90 Dipole.f90 Multipole.f90 EMfld.f90 TWS.f90 BeamLineElem.f90 CompDom.f90 Field.f90 BeamBunch.f90 Distribution.f90)
 
 target_link_libraries(impact_appl impact_func)
+if(USE_MPI)
+    target_link_libraries(impact_appl ${MPI_Fortran_LIBRARIES})
+endif()

--- a/src/Appl/CMakeLists.txt
+++ b/src/Appl/CMakeLists.txt
@@ -1,0 +1,24 @@
+
+#gfortran -c -O3 Appl/BPM.f90
+#gfortran -c -O3 Appl/CCL.f90
+#gfortran -c -O3 Appl/CCDTL.f90
+#gfortran -c -O3 Appl/DTL.f90
+#gfortran -c -O3 Appl/SC.f90
+#gfortran -c -O3 Appl/DriftTube.f90
+#gfortran -c -O3 Appl/Quadrupole.f90
+#gfortran -c -O3 Appl/ConstFoc.f90
+#gfortran -c -O3 Appl/SolRF.f90
+#gfortran -c -O3 Appl/Sol.f90
+#gfortran -c -O3 Appl/Dipole.f90
+#gfortran -c -O3 Appl/Multipole.f90
+#gfortran -c -O3 Appl/EMfld.f90
+#gfortran -c -O3 Appl/TWS.f90
+#gfortran -c -O3 Appl/BeamLineElem.f90
+#gfortran -c -O3 Appl/CompDom.f90
+#gfortran -c -O3 Appl/Field.f90
+#gfortran -c -O3 Appl/BeamBunch.f90
+#gfortran -c -O3 Appl/Distribution.f90
+
+add_library(impact_appl BPM.f90 CCL.f90 CCDTL.f90 DTL.f90 SC.f90 DriftTube.f90 Quadrupole.f90 ConstFoc.f90 SolRF.f90 Sol.f90 Dipole.f90 Multipole.f90 EMfld.f90 TWS.f90 BeamLineElem.f90 CompDom.f90 Field.f90 BeamBunch.f90 Distribution.f90)
+
+target_link_libraries(impact_appl impact_func)

--- a/src/Appl/mpif.h
+++ b/src/Appl/mpif.h
@@ -1,6 +1,0 @@
-      integer, parameter :: MPI_STATUS_SIZE = 1
-      integer, parameter :: MPI_PROC_NULL = 0
-      integer :: MPI_DOUBLE_PRECISION,MPI_DOUBLE_COMPLEX
-      integer :: MPI_INTEGER,MPI_SUM,MPI_COMM_WORLD
-      integer :: MPI_MIN, MPI_MAX
-!      double precision :: MPI_WTIME

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(ImpactZ Fortran)
+
+# Location of fortran modules:
+set(CMAKE_Fortran_MODULE_DIRECTORY
+    ${PROJECT_BINARY_DIR}/include/fortran/impact CACHE PATH "Single Directory for all fortran modules."
+)
+#gfortran -c -O3 mpistub.f90
+add_library(impact_mpi mpistub.f90)
+
+add_subdirectory(DataStruct)
+add_subdirectory(Func)
+add_subdirectory(Appl)
+add_subdirectory(Contrl)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,35 @@ project(ImpactZ Fortran)
 set(CMAKE_Fortran_MODULE_DIRECTORY
     ${PROJECT_BINARY_DIR}/include/fortran/impact CACHE PATH "Single Directory for all fortran modules."
 )
-#gfortran -c -O3 mpistub.f90
+
+if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    set(CMAKE_Fortran_FLAGS_DEBUG   "-Wall -fcheck=bounds ${CMAKE_Fortran_FLAGS_DEBUG}")
+    set(CMAKE_Fortran_FLAGS_RELEASE   "-O3 ${CMAKE_Fortran_FLAGS_RELEASE}")
+endif()
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    set(CMAKE_Fortran_FLAGS_DEBUG   "-Og -g -traceback -check bounds ${CMAKE_Fortran_FLAGS_DEBUG}")
+    set(CMAKE_Fortran_FLAGS_RELEASE   "-O3 ${CMAKE_Fortran_FLAGS_RELEASE}")
+endif()
+
 add_library(impact_mpi mpistub.f90)
 
+option(USE_MPI "Activate MPI build" OFF)
+
+if(USE_MPI)
+    find_package(MPI REQUIRED)
+    add_definitions(${MPI_Fortran_COMPILE_FLAGS})
+    include_directories(${MPI_Fortran_INCLUDE_PATH})
+    link_directories(${MPI_Fortran_LIBRARIES})
+    target_link_libraries(impact_mpi ${MPI_Fortran_LIBRARIES})
+endif()
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(DataStruct)
 add_subdirectory(Func)
 add_subdirectory(Appl)
 add_subdirectory(Contrl)
 
+enable_testing()
+add_test(NAME example1 COMMAND ImpactZ WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/Example1/)
+add_test(NAME example2 COMMAND ImpactZ WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/Example2/)
+add_test(NAME example3 COMMAND ImpactZ WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../examples/Example3/)

--- a/src/Contrl/CMakeLists.txt
+++ b/src/Contrl/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+#gfortran -c -O3 Contrl/Input.f90
+#gfortran -c -O3 Contrl/Output.f90
+#gfortran -c -O3 Contrl/AccSimulator.f90
+#gfortran -c -O3 Contrl/main.f90
+
+add_library(impact Input.f90 Output.f90 AccSimulator.f90)
+target_link_libraries(impact impact_datastruct impact_appl)
+
+add_executable(ImpactZ main.f90)
+target_link_libraries(ImpactZ impact)

--- a/src/Contrl/CMakeLists.txt
+++ b/src/Contrl/CMakeLists.txt
@@ -1,11 +1,10 @@
-
-#gfortran -c -O3 Contrl/Input.f90
-#gfortran -c -O3 Contrl/Output.f90
-#gfortran -c -O3 Contrl/AccSimulator.f90
-#gfortran -c -O3 Contrl/main.f90
-
 add_library(impact Input.f90 Output.f90 AccSimulator.f90)
 target_link_libraries(impact impact_datastruct impact_appl)
 
 add_executable(ImpactZ main.f90)
 target_link_libraries(ImpactZ impact)
+
+if(USE_MPI)
+    target_link_libraries(impact ${MPI_Fortran_LIBRARIES})
+    target_link_libraries(ImpactZ ${MPI_Fortran_LIBRARIES})
+endif()

--- a/src/Contrl/mpif.h
+++ b/src/Contrl/mpif.h
@@ -1,6 +1,0 @@
-      integer, parameter :: MPI_STATUS_SIZE = 1
-      integer, parameter :: MPI_PROC_NULL = 0
-      integer :: MPI_DOUBLE_PRECISION,MPI_DOUBLE_COMPLEX
-      integer :: MPI_INTEGER,MPI_SUM,MPI_COMM_WORLD
-      integer :: MPI_MIN, MPI_MAX
-!      double precision :: MPI_WTIME

--- a/src/DataStruct/CMakeLists.txt
+++ b/src/DataStruct/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+#gfortran -c -O3 DataStruct/NumConst.f90
+#gfortran -c -O3 DataStruct/PhysConst.f90
+#gfortran -c -O3 DataStruct/Pgrid.f90
+#gfortran -c -O3 DataStruct/Data.f90
+
+add_library(impact_datastruct NumConst.f90 PhysConst.f90 Pgrid.f90 Data.f90)
+
+target_link_libraries(impact_datastruct impact_mpi)

--- a/src/DataStruct/CMakeLists.txt
+++ b/src/DataStruct/CMakeLists.txt
@@ -1,9 +1,7 @@
-
-#gfortran -c -O3 DataStruct/NumConst.f90
-#gfortran -c -O3 DataStruct/PhysConst.f90
-#gfortran -c -O3 DataStruct/Pgrid.f90
-#gfortran -c -O3 DataStruct/Data.f90
-
 add_library(impact_datastruct NumConst.f90 PhysConst.f90 Pgrid.f90 Data.f90)
 
 target_link_libraries(impact_datastruct impact_mpi)
+if(USE_MPI)
+    target_link_libraries(impact_datastruct ${MPI_Fortran_LIBRARIES})
+endif()
+

--- a/src/DataStruct/mpif.h
+++ b/src/DataStruct/mpif.h
@@ -1,6 +1,0 @@
-      integer, parameter :: MPI_STATUS_SIZE = 1
-      integer, parameter :: MPI_PROC_NULL = 0
-      integer :: MPI_DOUBLE_PRECISION,MPI_DOUBLE_COMPLEX
-      integer :: MPI_INTEGER,MPI_SUM,MPI_COMM_WORLD
-      integer :: MPI_MIN, MPI_MAX
-!      double precision :: MPI_WTIME

--- a/src/Func/CMakeLists.txt
+++ b/src/Func/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+#gfortran -c -O3 Func/Timer.f90
+#gfortran -c -O3 Func/Transpose.f90
+#gfortran -c -O3 Func/Fldmger.f90
+#gfortran -c -O3 Func/Ptclmger.f90
+#gfortran -c -O3 Func/FFT.f90
+
+add_library(impact_func Timer.f90 Transpose.f90 Fldmger.f90 Ptclmger.f90 FFT.f90)
+
+target_link_libraries(impact_func impact_mpi)

--- a/src/Func/CMakeLists.txt
+++ b/src/Func/CMakeLists.txt
@@ -1,10 +1,6 @@
-
-#gfortran -c -O3 Func/Timer.f90
-#gfortran -c -O3 Func/Transpose.f90
-#gfortran -c -O3 Func/Fldmger.f90
-#gfortran -c -O3 Func/Ptclmger.f90
-#gfortran -c -O3 Func/FFT.f90
-
 add_library(impact_func Timer.f90 Transpose.f90 Fldmger.f90 Ptclmger.f90 FFT.f90)
 
-target_link_libraries(impact_func impact_mpi)
+target_link_libraries(impact_func impact_datastruct impact_mpi)
+if(USE_MPI)
+    target_link_libraries(impact_func ${MPI_Fortran_LIBRARIES})
+endif()

--- a/src/Func/mpif.h
+++ b/src/Func/mpif.h
@@ -1,6 +1,0 @@
-      integer, parameter :: MPI_STATUS_SIZE = 1
-      integer, parameter :: MPI_PROC_NULL = 0
-      integer :: MPI_DOUBLE_PRECISION,MPI_DOUBLE_COMPLEX
-      integer :: MPI_INTEGER,MPI_SUM,MPI_COMM_WORLD
-      integer :: MPI_MIN, MPI_MAX
-!      double precision :: MPI_WTIME


### PR DESCRIPTION
Please consider this nothing but a proposal, there are both benefits and drawbacks to this suggestion. I think the choice strongly depends on the developers preference.

CMake offers more complex build setup, e.g. supporting multiple compilers, accurate linking of libraries, out of source builds, correct use of rpath for binaries in test folders, tools for running test suites etc. Specifically for fortran, it should be noted that it has functionality to automatically figure out module dependencies so you compile big projects in the right order. If you ever tried to do this manually you know how frustrating it can be. Compiling in parallel is supported (`make -j4` for example). Some further discussion can be found e.g. here: http://fortranwiki.org/fortran/show/Build+tools

On the drawback it adds dependencies and are perhaps at least at first more confusing to use. For simple projects I can imagine it might feel a bit overkill sometimes.

The very basic usage is "create a folder to build in, configure with cmake, run make as usual". In commands terms that means (starting from top level folder):
```
mkdir build && cd build
cmake ../src
make
```

After building, you can also optionally run the three examples with the command `ctest`.

In the current proposal I have added debug and release build flags for ifort and gfortran. By default neither are used. To e.g. configure with debug flags, use `cmake -DCMAKE_BUILD_TYPE=Debug ..`

For compiling with MPI I did not quite understand how it should be done, since (if I understand correctly) the current Makefile does not show it. I put up the functionality for it, but there are probably some things which are wrong. Notably I had some issue with a double definition of MPI_WTIME?