### PR TITLE
Fix: GCC 10 and MPI `-fallow-argument-mismatch`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,16 @@ if(USE_MPI)
     target_compile_definitions(${OUTPUT_NAME} PUBLIC USE_MPI)
     target_link_libraries(${OUTPUT_NAME} PUBLIC MPI::MPI_Fortran)
     include_directories(${MPI_Fortran_INCLUDE_PATH})
+
+    # Allow type mismatch for GCC 10
+    # (Adapted from from: https://github.com/Unidata/netcdf-fortran/blob/main/CMakeLists.txt)
+    # Check to see if compiler supports
+    # -fallow-argument-mismatch-flag introduced in gcc 10.
+    include(CheckFortranCompilerFlag)
+    check_fortran_compiler_flag("-fallow-argument-mismatch" COMPILER_HAS_ALLOW_ARGUMENT_MISMATCH)
+    if(COMPILER_HAS_ALLOW_ARGUMENT_MISMATCH)
+        target_compile_options(${OUTPUT_NAME} PRIVATE "-fallow-argument-mismatch")
+    endif(COMPILER_HAS_ALLOW_ARGUMENT_MISMATCH)
 else()
     # Add mpistub to source list
     list(APPEND _sources mpistub.f90)


### PR DESCRIPTION
With GCC 10, Fortran checks types in API signatures.
Currently, MPI does not properly cast types.

Same as
https://github.com/impact-lbl/IMPACT-T/pull/19

cc @ChristopherMayes @qianglbl