### PR TITLE
Fix particle output precision by letting Fortran decide decimal places

### DIFF
--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -1840,8 +1840,8 @@
                         MPI_COMM_WORLD,ierr)
         endif
 
-100     format(9(1x,e14.7))
-101     format(6(1x,e14.7))
+100     format(9(1x,g0))
+101     format(6(1x,g0))
 
         deallocate(nptlist)
         deallocate(recvbuf)


### PR DESCRIPTION
The `G0` format specifier appears to be a Fortran 2008 addition:

https://gcc.gnu.org/onlinedocs/gcc-5.4.0/gfortran/Fortran-2008-status.html

Before this PR, particle output can have such low precision that round-tripping particle representations to Impact-Z results in non-equivalent particle data.

What this change looks like in a particle file:

_Before this PR_
```
$ cat pre-fort.2000
  0.2095845E-10  0.1956951E+01  0.4191690E-10  0.3913902E+01  0.1884956E-01 -0.1856951E+02 -0.1956951E-05  0.1000000E+01  0.0000000E+00
```

_After this PR_
```
$ cat fort.2000
 0.20958450219516818E-10 1.9569511835591835 0.41916900439033635E-10 3.9139023671183670 0.18849555921538759E-1 -18.569509878640652 -0.19569511835591837E-5 1.0000000000000000 0.0000000000000000
```

cc @christophermayes