### PR TITLE
FIX: remove leading space in particle output; segfault with distribution_type=2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,17 @@ jobs:
           cd $GITHUB_WORKSPACE/examples/Example1
           $GITHUB_WORKSPACE/src/ImpactZexe
 
-      - name: Test - MPI - ${{ matrix.mpi }}
-        if: matrix.mpi != 'nompi'
+      - name: Test - mpich
+        if: matrix.mpi == 'mpich'
+        run: |
+          cd $GITHUB_WORKSPACE/examples/Example1
+          # NOTE: MPICH on GitHub Actions runners fail to allocate more than 1
+          # process for the communicator. We're only testing that the MPI
+          # executable doesn't fail outright here.
+          mpirun -n 1 $GITHUB_WORKSPACE/src/ImpactZexe-mpi
+
+      - name: Test - OpenMPI
+        if: matrix.mpi == 'openmpi'
         run: |
           cd $GITHUB_WORKSPACE/examples/Example1
           sed -i"" '11s/1 1/2 1/' ImpactZ.in

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        mpi: ['nompi', 'openmpi', 'mpich']
+        os: ["ubuntu-latest"]
+        mpi: ["nompi", "openmpi", "mpich"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
         if: matrix.mpi != 'nompi'
         run: |
           cd src/
-          make FC=mpifort LINK=mpifort USE_MPI=1
+          FFLAGS="$FFLAGS -fallow-argument-mismatch" make FC=mpifort LINK=mpifort USE_MPI=1
 
       - name: Test - No MPI
         if: matrix.mpi == 'nompi'
@@ -48,14 +48,13 @@ jobs:
           sed -i"" '11s/1 1/2 1/' ImpactZ.in
           mpirun -n 2 $GITHUB_WORKSPACE/src/ImpactZexe-mpi
 
-
   cmake:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        mpi: [ nompi, openmpi, mpich ]
+        os: [ubuntu-latest]
+        mpi: [nompi, openmpi, mpich]
     steps:
       - uses: actions/checkout@v2
       - name: Install GFortran

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,9 +90,30 @@ jobs:
           cd $GITHUB_WORKSPACE/examples/Example1
           $GITHUB_WORKSPACE/build/ImpactZexe
 
-      - name: Test - MPI - ${{ matrix.mpi }}
-        if: matrix.mpi != 'nompi'
+      - name: Test - mpich
+        if: matrix.mpi == 'mpich'
+        run: |
+          cd $GITHUB_WORKSPACE/examples/Example1
+          # NOTE: MPICH on GitHub Actions runners fail to allocate more than 1
+          # process for the communicator. We're only testing that the MPI
+          # executable doesn't fail outright here.
+          mpirun -n 1 $GITHUB_WORKSPACE/build/ImpactZexe-mpi
+
+      - name: Test - OpenMPI
+        if: matrix.mpi == 'openmpi'
         run: |
           cd $GITHUB_WORKSPACE/examples/Example1
           sed -i"" '11s/1 1/2 1/' ImpactZ.in
           mpirun -n 2 $GITHUB_WORKSPACE/build/ImpactZexe-mpi
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.mpi != 'nompi'
+        with:
+          name: ImpactZ-${{ matrix.os }}-${{ matrix.mpi }}
+          path: build/ImpactZexe-mpi
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.mpi == 'nompi'
+        with:
+          name: ImpactZ-${{ matrix.os }}-${{ matrix.mpi }}
+          path: build/ImpactZexe

--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -581,9 +581,11 @@
         enddo
 
         do i = 1, innp
-          iitmp = epsiontmp(i)/hxeps
-          nii = iitmp+1
-          tmpbin(nii) = tmpbin(nii) + 1 
+          if (.not. isnan(epsiontmp(i))) then
+            iitmp = epsiontmp(i)/hxeps
+            nii = iitmp+1
+            tmpbin(nii) = tmpbin(nii) + 1 
+          endif
         enddo
 
         glbin = 0
@@ -720,9 +722,11 @@
         enddo
 
         do i = 1, innp
-          iitmp = epsiontmp(i)/hyeps
-          nii = iitmp+1
-          tmpbin(nii) = tmpbin(nii) + 1
+          if (.not. isnan(epsiontmp(i))) then
+            iitmp = epsiontmp(i)/hyeps
+            nii = iitmp+1
+            tmpbin(nii) = tmpbin(nii) + 1
+          endif
         enddo
         glbin = 0
         call MPI_ALLREDUCE(tmpbin,glbin,nbin,MPI_INTEGER,&
@@ -851,9 +855,11 @@
         enddo
 
         do i = 1, innp
-          iitmp = epsiontmp(i)/hzeps
-          nii = iitmp+1
-          tmpbin(nii) = tmpbin(nii) + 1
+          if (.not. isnan(epsiontmp(i))) then
+            iitmp = epsiontmp(i)/hzeps
+            nii = iitmp+1
+            tmpbin(nii) = tmpbin(nii) + 1
+          endif
         enddo
         glbin = 0
         call MPI_ALLREDUCE(tmpbin,glbin,nbin,MPI_INTEGER,&

--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -1840,8 +1840,8 @@
                         MPI_COMM_WORLD,ierr)
         endif
 
-100     format(9(1x,g0))
-101     format(6(1x,g0))
+100     format(9(g0,1x))
+101     format(6(g0,1x))
 
         deallocate(nptlist)
         deallocate(recvbuf)


### PR DESCRIPTION
## Three fixes

* A fix for segfaulting in certain scenarios with output distribution_type 2
* A minor fix for leading spaces in particle output
* A fix for GitHub Actions scripts that were failing to build/test

### A crash when calculating `distribution_type=2` output

I encountered a segfault when using `distribution_type=2` and dealing with single particles that I did not see with `distribution_type=1`. The calculated statistics are `NaN`, leading to the array indexing being invalid. Here's a sample backtrace:

```
Program received signal SIGSEGV, Segmentation fault.
b0x00005e9699887a72 in outputclass::diagnostic2_output (this=..., z=0, nchrg=0, nptlist=...)
    at /home/user/IMPACT-Z/src/Contrl/Output.f90:586
586               tmpbin(nii) = tmpbin(nii) + 1
(gdb) bt
#0  0x00005e9699887a72 in outputclass::diagnostic2_output (this=..., z=0, nchrg=0, nptlist=...)
    at /home/user/IMPACT-Z/src/Contrl/Output.f90:586
#1  0x00005e9699893af0 in accsimulatorclass::run_accsimulator ()
    at /home/user/IMPACT-Z/src/Contrl/AccSimulator.f90:621
#2  0x00005e96997e408f in MAIN__ () at /home/user/IMPACT-Z/src/Contrl/main.f90:24
#3  main (argc=<optimized out>, argv=<optimized out>) at /home/user/IMPACT-Z/src/Contrl/main.f90:18
#4  0x000078e4734afd90 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x000078e4734afe40 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#6  0x00005e96997e40df in _start ()
```

The proposed fix in this PR is to simply check for `NaN` prior to updating the output statistics.

### A small follow-up to #11: remove leading spaces in particle text file output

This fixes the leading spaces in output particle files. This saves a bit of space and makes it slightly easier for not-so-smart parsers to read the output particles (specifically `polars.read_csv` on our end, which can be ~10x faster than `numpy.loadtxt` for large particle output files).

Currently particles look like this:
```
 2.7245985285371863 0.0000000000000000 0.27245985285371860 0.0000000000000000 0.0000000000000000 0.19518154541019361 -0.19569511835591837E-5 1.0000000000000000 0.0000000000000000
```
After this PR, the leading space should be removed:
```
2.7245985285371863 0.0000000000000000 0.27245985285371860 0.0000000000000000 0.0000000000000000 0.19518154541019361 -0.19569511835591837E-5 1.0000000000000000 0.0000000000000000
```

Fortunately, there does not appear to be a trailing space inserted with `9(g0,1x)`.

### GitHub Actions changes

* A necessary flag for the standard GNU `make` workflow to work with modern compilers wasn't being passed (`-fallow-argument-mismatch`)
* `MPICH` on GitHub Actions appears to have issues assigning the number of requested processors for the communicator
   * This made running the first example with 2+ cores impossible. (See notes below)
   * It would result in the error: `MPIR_Cart_create_impl(41): Size of the communicator (1) is smaller than the size of the Cartesian topology (2)`
   * I adjusted MPICH to only run 1x1 processes, to at least verify that the build worked.

Using `tmate` to access a GitHub Actions instance, I poked around a bit and found that even a simple MPICH program was unable to function correctly:

<details>

```bash
$ cat hello.f90
        PROGRAM hello_world_mpi
        include 'mpif.h'

        integer process_Rank, size_Of_Cluster, ierror, tag

        call MPI_INIT(ierror)
        call MPI_COMM_SIZE(MPI_COMM_WORLD, size_Of_Cluster, ierror)
        call MPI_COMM_RANK(MPI_COMM_WORLD, process_Rank, ierror)

        print *, 'Hello World from process: ', process_Rank, 'of ', size_Of_Cluster

        call MPI_FINALIZE(ierror)
        END PROGRAM

runner@fv-az1940-871:~/work/IMPACT-Z/IMPACT-Z/examples/Example1$ mpif90 hello.f90 -o test_mpi
runner@fv-az1940-871:~/work/IMPACT-Z/IMPACT-Z/examples/Example1$ mpirun -np 2 ./test_mpi
 Hello World from process:            0 of            1
 Hello World from process:            0 of            1
runner@fv-az1940-871:~/work/IMPACT-Z/IMPACT-Z/examples/Example1$ mpirun -np 4 ./test_mpi
 Hello World from process:            0 of            1
 Hello World from process:            0 of            1
 Hello World from process:            0 of            1
 Hello World from process:            0 of            1
```
</details>

However, the compiled executable worked just fine with MPICH on a non-virtualized machine. I am not an MPI expert, but I think this justifies the CI test suite change.

cc @christophermayes

