### PR TITLE
FIX: diagnostic output precision

### DIFF
--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -362,9 +362,9 @@
           call flush(32)
         endif
 
-99      format(8(1x,e13.6))
-100      format(7(1x,e13.6))
-101     format(1x,e13.6,3I10)
+99      format(8(1x,g0))
+100      format(7(1x,g0))
+101     format(1x,g0,3I10)
 
         t_diag = t_diag + elapsedtime_Timer(t0)
 
@@ -1082,10 +1082,10 @@
 !                     glmax(5),glmax(6)
         endif
 
-99      format(6(1x,e13.6))
-100      format(10(1x,e13.6))
-101     format(1x,e13.6,3I13)
-102      format(7(1x,e13.6))
+99      format(6(1x,g0))
+100      format(10(1x,g0))
+101     format(1x,g0,3I13)
+102      format(7(1x,g0))
 
         t_diag = t_diag + elapsedtime_Timer(t0)
 
@@ -1360,9 +1360,9 @@
           call flush(40)
         endif
 
-99      format(6(1x,e13.6))
-100      format(7(1x,e13.6))
-101     format(1x,e13.6,3I10)
+99      format(6(1x,g0))
+100      format(7(1x,g0))
+101     format(1x,g0,3I10)
 
         t_diag = t_diag + elapsedtime_Timer(t0)
 

--- a/src/INSTRUCTIONS.md
+++ b/src/INSTRUCTIONS.md
@@ -23,6 +23,33 @@ If you are new to CMake, [this short tutorial](https://hsf-training.github.io/hs
 
 If you just want to use CMake to build the project, jump into sections *1. Introduction*, *2. Building with CMake* and *9. Finding Packages*.
 
+## Using conda to compile IMPACT-Z
+
+`conda-forge` has all of the necessary compilers and dependencies to build IMPACT-Z from source.
+
+Create a build environment like so:
+
+```bash
+conda create -n impactz-build -c conda-forge compilers cmake openmpi
+conda activate impactz-build
+```
+
+Then to build the non-parallel version:
+
+```bash
+cmake -S src/ -B build-single
+cmake --build build-single -j 4
+ls build-single/ImpactZexe
+```
+
+And to build the MPI-parallelized version with OpenMPI:
+
+```bash
+cmake -S src/ -B build-mpi -DUSE_MPI=ON
+cmake --build build-mpi -j 4
+ls build-mpi/ImpactZexe-mpi
+```
+
 ## Unix
 
 ### Single Processor Code:


### PR DESCRIPTION
## Changes

1. Adjust diagnostic output modes 1 and 2 to use `g0` to format floating point values
2. Add simple compilation instructions using conda-forge's compilers (supersedes #13 ; a single-click merge for your convenience). This is the same as in Impact-T and what @christophermayes and I use locally.

