### PR TITLE
 Extend transient CSR to all elements downstream of a bend

### DIFF
--- a/src/Appl/BeamBunch.f90
+++ b/src/Appl/BeamBunch.f90
@@ -3743,6 +3743,8 @@
           ix1=ix+1
           jx1=jx+1
           kx1=kx+1
+          if(ix.lt.1 .or. ix1.gt.innx .or. jx.lt.1 .or. jx1.gt.inny &
+             .or. kx.lt.1 .or. kx1.gt.innz) cycle
           ! (i,j,k):
           rho(ix,jx,kx) = rho(ix,jx,kx) + ab*cd*ef*rays(8,i)
           ! (i,j+1,k):

--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -625,6 +625,7 @@
         double precision :: xx,yy,t3dstart,rr,tmger,tmpwk
         double precision  :: aawk,ggwk,lengwk,hzwake,ab
         integer :: flagwake,flagwakeread,flagbtw,iizz,iizz1,kz,kadd,ipt,flagcsr,flagcsrTr
+        integer :: flagbendcsr
         !for bending magnet Transport transfer matrix implementation
         double precision :: hd0,hd1,dstr1,dstr2,angF,tanphiF,tanphiFb,&
             angB,tanphiB,tanphiBb,hF,hB,qm0,qmi,psi1,psi2,r0,gamn,gambet,&
@@ -635,6 +636,7 @@
         !for csr wake
         integer :: bitypeold,bitypeold2
         real*8 :: zwkmin,bendlen,zbleng,blengthold,blengthold2
+        real*8 :: bendlencsr,sentr
         real*8 :: tmplump,b0,qmass,qchg,pmass, alphax0,betax0,alphay0,betay0,scwk
         integer :: nslice,ihlf
         real*8 :: rsiglaser,rlaserwvleng
@@ -719,6 +721,9 @@
         flagsc = 1
         flagcsr = 0
         flagcsrTr = 0
+        flagbendcsr = 0
+        bendlencsr = 0.0d0
+        sentr = 0.0d0
         aawk = 0.05
         ggwk = 0.05
         lengwk = 0.1
@@ -1032,6 +1037,18 @@
               else
                 flagcsrTr = 0
               endif
+              !Capture this bend's geometry so that ALL downstream elements
+              !(not just the 1st/2nd) can apply the transient drift CSR wake
+              !with the correct bend length. sentr accumulates the distance
+              !from this bend's entrance; it is reset here and incremented by
+              !each element length at the end of the beam-line-element loop.
+              if(flagcsrTr.eq.1) then
+                flagbendcsr = 1
+                bendlencsr = blength
+                sentr = 0.0d0
+              else
+                flagbendcsr = 0
+              endif
               !if((bitype.eq.0) .and. (bitypeold.eq.4) .and. &
               if(((bitypeold.eq.4) .or. (bitypeold2.eq.4)) .and. &
                 (flagcsrTr.eq.1)) then
@@ -1112,12 +1129,12 @@
                                    Flagbc,Perdlen,piperad,piperad2)
               call chgupdate_BeamBunch(Bpts,nchrg,nptlist0,qmcclist0)
               flagcsr = 0
-              !if(bitype.eq.4) then
-              if(bitype.eq.4 .or. ((bitypeold2.eq.4 .or. bitypeold.eq.4) &
-                                  .and. flagcsrTr.eq.1)) then
-                if(dparam(4).gt.200) then
-                  flagcsr = 1
-                endif
+              if(bitype.eq.4) then
+                !CSR inside the bend (steady-state + entrance transient)
+                if(dparam(4).gt.200) flagcsr = 1
+              else if(flagbendcsr.eq.1) then
+                !transient (drift) CSR in ANY element downstream of a bend
+                flagcsr = 1
               endif
 
               !fix the global range for sub-cycle of space charge potential.
@@ -1355,19 +1372,16 @@
                 !densz(Nz) = densz(Nz)*2
 
                 if(bitype.eq.4) then
+                   !inside the bend: entrance is the start of this element
                    zwkmin = range(5)/(-Bpts%refptcl(6)) + (z-zbleng)
-                   bendlen = blength !inside the bend
+                   bendlen = blength
                 else
-                   if(bitypeold.eq.4) then !1st element after bend
-                     zwkmin = range(5)/(-Bpts%refptcl(6)) + (z-zbleng+blengthold)
-                     bendlen = blengthold !out of the bend
-                   else if(bitypeold2.eq.4) then !2nd element after bend
-                     zwkmin = range(5)/(-Bpts%refptcl(6)) + &
-                              (z-zbleng+blengthold+blengthold2)
-                     bendlen = blengthold2 !out of the bend
-                   else
-                     print*,"Not available for csr!"
-                   endif
+                   !downstream of the bend: use the retained bend length and
+                   !the distance from the bend entrance accumulated in sentr.
+                   !r0 still holds the most recent bend's radius (it is only
+                   !set in the bend branch), so it is correct here.
+                   zwkmin = range(5)/(-Bpts%refptcl(6)) + (z-zbleng+sentr)
+                   bendlen = bendlencsr
                 endif
 
                 exwake = 0.0
@@ -1482,6 +1496,7 @@
           !      call geomerrT_BeamBunch(Bpts,Blnelem(i)) 
           !end if
           zbleng = zbleng + blength
+          sentr = sentr + blength
           bitypeold2 = bitypeold
           blengthold2 = blengthold
           bitypeold = bitype

--- a/src/Contrl/Input.f90
+++ b/src/Contrl/Input.f90
@@ -309,9 +309,9 @@
               value7(i),value8(i),value9(i),value10(i),value11(i),value12(i),&
               value13(i),value14(i),value15(i),value16(i),value17(i),value18(i),&
               value19(i),value20(i),value21(i),value22(i),value23(i),value24(i)
-            endif
-            if(obtype(i).eq.-99)then
-              goto 789
+              if(obtype(i).eq.-99)then
+                goto 789
+              endif
             endif
           goto 123
 789       continue

--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -598,7 +598,7 @@
           do i = 2, nbin
             glbin(i) = glbin(i) + glbin(i-1)
           enddo
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f90) then
               ex90 = ((f90 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hxeps+&
                     hxeps*(i-1) 
@@ -606,7 +606,7 @@
             endif
           enddo
           !print*,"i1: ",i,nbin,glbin(i-1),glbin(i),f90,f95,f99
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f95) then
               ex95 = ((f95 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hxeps+&
                     hxeps*(i-1) 
@@ -614,7 +614,7 @@
             endif
           enddo
           !print*,"i2: ",i,nbin,glbin(i-1),glbin(i)
-          do i =1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f99) then
               ex99 = ((f99 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hxeps+&
                     hxeps*(i-1) 
@@ -735,7 +735,7 @@
           do i = 2, nbin
             glbin(i) = glbin(i) + glbin(i-1)
           enddo
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f90) then
               ey90 = ((f90 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hyeps+&
                     hyeps*(i-1)
@@ -743,7 +743,7 @@
             endif
           enddo
           !print*,"i4: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f95) then
               ey95 = ((f95 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hyeps+&
                     hyeps*(i-1)
@@ -751,7 +751,7 @@
             endif
           enddo
           !print*,"i5: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f99) then
               ey99 = ((f99 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hyeps+&
                     hyeps*(i-1)
@@ -868,7 +868,7 @@
           do i = 2, nbin
             glbin(i) = glbin(i) + glbin(i-1)
           enddo
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f90) then
               ez90 = ((f90 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hzeps+&
                     hzeps*(i-1)
@@ -876,7 +876,7 @@
             endif
           enddo
           !print*,"i7: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f95) then
               ez95 = ((f95 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hzeps+&
                     hzeps*(i-1)
@@ -884,7 +884,7 @@
             endif
           enddo
           !print*,"i8: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f99) then
               ez99 = ((f99 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hzeps+&
                     hzeps*(i-1)
@@ -1013,7 +1013,7 @@
           do i = 2, nbin
             glbin(i) = glbin(i) + glbin(i-1)
           enddo
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f90) then
               r90 = ((f90 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hreps+&
                     hreps*(i-1)
@@ -1021,7 +1021,7 @@
             endif
           enddo
           !print*,"i10: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f95) then
               r95 = ((f95 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hreps+&
                     hreps*(i-1)
@@ -1029,7 +1029,7 @@
             endif
           enddo
           !print*,"i11: ",i,nbin,glbin(i-1),glbin(i)
-          do i = 1, nbin
+          do i = 2, nbin
             if(glbin(i).gt.f99) then
               r99 = ((f99 - glbin(i-1))/(glbin(i)-glbin(i-1)))*hreps+&
                     hreps*(i-1)

--- a/src/Func/Ptclmger.f90
+++ b/src/Func/Ptclmger.f90
@@ -51,7 +51,7 @@
         if(Nptlocal.gt.480) then
           nsmall = Nptlocal/16
         else
-          nsmall = Nptlocal
+          nsmall = max(Nptlocal,1)
         endif
         allocate(left(9,nsmall))
         allocate(right(9,nsmall))
@@ -289,7 +289,7 @@
         deallocate(temp1)
 
         !send outgoing particles to left neibhoring processor.
-        allocate(temp1(9,jleft))
+        allocate(temp1(9,max(jleft,1)))
         temp1 = 0.0
         if(myidx.ne.0) then
           ileft = 9*ileft
@@ -312,7 +312,7 @@
         
 !        call MPI_BARRIER(comm2d,ierr)
         !send outgoing particles to right neibhoring processor.
-        allocate(temp1(9,jright))
+        allocate(temp1(9,max(jright,1)))
         temp1 = 0.0
         if(myidx.ne.(npx-1)) then
           iright = 9*iright
@@ -336,7 +336,7 @@
 
 !        call MPI_BARRIER(comm2d,ierr)
         !send outgoing particles to down neibhoring processor.
-        allocate(temp1(9,jdown))
+        allocate(temp1(9,max(jdown,1)))
         temp1 = 0.0
         if(myidy.ne.0) then
           idown = 9*idown
@@ -360,7 +360,7 @@
 
 !        call MPI_BARRIER(comm2d,ierr)
         !send outgoing particles to up neibhoring processor.
-        allocate(temp1(9,jup))
+        allocate(temp1(9,max(jup,1)))
         temp1 = 0.0
         if(myidy.ne.(npy-1)) then
           iup = 9*iup
@@ -390,7 +390,7 @@
         if(numbuf.gt.480) then
           nsmall = numbuf/16
         else
-          nsmall = numbuf
+          nsmall = max(numbuf,1)
         endif
         allocate(left(9,nsmall))
         allocate(right(9,nsmall))


### PR DESCRIPTION
## Summary

Removes the long-standing restriction that transient (drift) CSR is applied only to the **first and second** beam-line elements after a bend. With this change the transient CSR wake is applied to **every** element downstream of a bend, so the CSR effect is no longer truncated and is independent of how the drift region is segmented.

Builds on PR #17 (`fix-out-of-bound-access`).

## Motivation

The 1D CSR wake kernel `csrwakeTrIGF_FieldQuant` (`src/Appl/Field.f90`) already implements the full Saldin et al. model, including the post-bend drift transient (Cases C and D), which is valid for arbitrary distance past a bend. However, the driver in `src/Contrl/AccSimulator.f90` only tracked **two** elements of history (`bitypeold`, `bitypeold2`) and had three hard-coded geometry cases (in-bend, 1st-after, 2nd-after). Any element beyond the second after a bend silently received no CSR.

Consequently, breaking a post-bend drift into several shorter drifts (a common way to increase resolution) **truncates** the CSR effect after the second fragment. The `examples/CSR/zeuthen` chicane demonstrates this: `ZB.PIP03` is split into `0.1 / 0.1 / 4.8 m`, and the 4.8 m fragment previously got no CSR.

## Change

The fix is bookkeeping only — no changes to the physics kernel:

- **Retain the most recent bend's geometry** across elements: `flagbendcsr` (is there an upstream bend requesting transient CSR), `bendlencsr` (its arc length). `r0` already persists as the last bend's radius since it is only assigned in the bend branch.
- **Accumulate the distance from the bend entrance** in `sentr`, incremented by each element length at the end of the beam-line-element loop and reset to 0 at each new bend.
- **Apply CSR to all downstream elements**: `flagcsr` is set for the bend itself and for every element while `flagbendcsr == 1`.
- **Unify the geometry** into a single downstream formula
  (`zwkmin = range(5)/gamma + (z - zbleng + sentr)`, `bendlen = bendlencsr`),
  replacing the 1st/2nd-after special cases and the dead `"Not available for csr!"` branch.

### Scope / model

- **Single most-recent-bend model** (unchanged): each drift region uses the geometry of the nearest upstream bend. A new bend replaces the retained geometry.
- **Multi-bend superposition is intentionally out of scope.** Summing contributions from several upstream bends is not compatible with the Saldin fixed-geometry case approach (the geometry changes between bends) and would require a fundamentally different algorithm. This PR does not attempt it.
- **On/off control** is the bend's existing switch: `input_switch (dparam(4)) > 500` enables transient CSR, which now propagates to all downstream elements; `> 200` enables CSR inside the bend. No input-format change.

## Validation

`zeuthen` chicane (attached as `imactz_csr_zeuthen.zip` — see Notes), 100k particles, `mpirun -n 8`. Split-invariance test — CSR must not depend on how the post-bend drift is segmented:

| final quantity        | before (split, truncated) | after (split) | after (single 5 m drift) |
|-----------------------|---------------------------|---------------|--------------------------|
| fort.26 z, col 4      | 1.4688                    | **2.2074**    | **2.2074**               |
| fort.26 z, col 6      | 9.5005                    | **10.0662**   | **10.0663**              |
| fort.24 x, col 6      | +0.04082                  | **−0.02246**  | **−0.02246**             |

- After the change, the split and single-drift lattices agree to 6–7 significant figures → CSR is applied consistently regardless of segmentation.
- The previous (truncated) result differs substantially (the transverse moment even changes sign), confirming the old behavior was dropping a physically significant CSR contribution over the long drift.

## Files Changed

| File | Change |
|------|--------|
| `src/Contrl/AccSimulator.f90` | Retain post-bend geometry (`flagbendcsr`, `bendlencsr`, `sentr`); apply transient CSR to all downstream elements; unify the wake-geometry computation |

## Notes

- The validation lattice (`zeuthen` chicane) is **attached to this PR as `impactz_csr_zeuthen.zip`**, not committed to the repository. A proper in-repo example will be added in a follow-up.
- The `NaN` values in the last three columns of `fort.26` are a pre-existing extended-diagnostic artifact, unrelated to this change (identical before and after).

## Attachments

[impactz_csr_zeuthen.zip](https://github.com/user-attachments/files/29678295/impactz_csr_zeuthen.zip)


## Acknowledgment

The investigation, implementation, and validation for this change were carried out with the assistance of Claude (Anthropic), used via GitHub Copilot.
